### PR TITLE
Load folders

### DIFF
--- a/src/stores/audiofiles.ts
+++ b/src/stores/audiofiles.ts
@@ -35,19 +35,29 @@ export const useAudioFiles = defineStore("audiofiles", () => {
       return
     }
 
-    const audio = await ctx.decodeAudioData(file)
-    if (audio.duration > maxDuration) {
+    if (durationExceeded.value) {
       messagesStore.addMessage(
-        `Rejected "${name}", too long (>${maxDuration}s).`,
+        `Rejected "${name}", total duration > ${maxDuration}.`,
         "warning",
         { timeout: 8500 },
       )
       return
     }
 
-    if (totalDuration.value > 45) {
+    let audio: AudioBuffer
+    try {
+      audio = await ctx.decodeAudioData(file)
+    } catch (e) {
       messagesStore.addMessage(
-        `Rejected "${name}", total duration > ${maxDuration}.`,
+        `Rejected "${name}", invalid audio file.`,
+        "error",
+        { timeout: 8500 },
+      )
+      return
+    }
+    if (audio.duration > maxDuration) {
+      messagesStore.addMessage(
+        `Rejected "${name}", too long (>${maxDuration}s).`,
         "warning",
         { timeout: 8500 },
       )


### PR DESCRIPTION
File inputs can only accept files OR folders, but not both at the same time.

This PR uses the drag & drop FileTransfer API. By adding a drag handler on the label drop events can be intercepted before they reach the file input.

Even though this PR uses a method prefixed with webkit it does work on FireFox. One weird thing I noticed is that in FireFox the type (mimetype) of a file is the empty string if the file is loaded through FileSystemDirectoryEntry reader api. This means I cannot reject non-audio files early, and have to go through the decodeAudioData call in order to detect invalid files.

Extra care is taken to load the files in a directory in a deterministic way. First all the files are loaded (in alphabetical order) before recursing into directories (again in alphabetical order).

The file loading has been changed to stop as soon as one of the limits is reached. This is to prevent spurious "rejcected file" messages.

If a users drops a directory full with invalid files there will still be a error message overload.